### PR TITLE
Add automatic scheduled weekly CI run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,8 @@ on:
       - 'main'
   push:
     branches: [ main ]
+  schedule:
+    - cron: '0 7 * * 6'
 
 jobs:
   test_latest:


### PR DESCRIPTION
This is needed to ensure our shard is always compatible with the latest Crystal